### PR TITLE
update bastion agent to pick external ip for fabric

### DIFF
--- a/basestation/basestationAgent/basestationAgent.py
+++ b/basestation/basestationAgent/basestationAgent.py
@@ -460,7 +460,7 @@ class FlyPawBasestationAgent(object):
                                 thisResourceInfo.purpose = "mission" #get from mission somehow
                             
                                 m_ip = ("management", n.get_management_ip())
-                                e_ip = ("external", n.get_management_ip()) #for fabric these will not be the same 
+                                e_ip = ("external", n.get_external_ip()) #for fabric these will not be the same
                                 thisResourceInfo.resourceAddresses.append(m_ip)
                                 thisResourceInfo.resourceAddresses.append(e_ip)
                                 thisResourceInfo.state = n.get_reservation_state()

--- a/basestation/basestationAgent/sample_config.yml
+++ b/basestation/basestationAgent/sample_config.yml
@@ -17,6 +17,7 @@ resources:
         name_prefix: node
         network:
           type: IPv6 # Allowed values IPv4 or IPv6
+          local_nw_subnet: "192.168.1.0/24"
         flavor:
           cores: 2
           ram: 8


### PR DESCRIPTION
- Mobius is updated to create a topology with all VMs requested being connected to each other via L2Bridge
- Each VM is also connected to Fabnetv*Ext - IPv4/IPv6 can be specified in `sample_config.yml` 
- Also, local network subnet to choose for L2Bride connecting all VMs can be specified in `sample_config.yml` 
```
        network:
          type: IPv6 # Allowed values IPv4 or IPv6
          local_nw_subnet: "192.168.1.0/24"
```
- bastionAgent.py is updated to extract external ip for a fabric node via `n.get_external_ip()`
Please use `mobius-py>=1.3.1` version in addition to the above config as needed.
